### PR TITLE
修复微信登录覆盖用户自定义头像的问题 - 分离登录和注册逻辑：老用户登录时不再更新个人资料 - 云托管登录：老用户只更新登录时间，保护现有…

### DIFF
--- a/reminder-backend/reminder-core/src/main/java/com/core/reminder/config/WechatConfig.java
+++ b/reminder-backend/reminder-core/src/main/java/com/core/reminder/config/WechatConfig.java
@@ -23,6 +23,11 @@ public class WechatConfig {
     private String secret = "b70c1fd582a6f6d66e8dc1e2e436d023";
 
     /**
+     * 微信云开发环境ID
+     */
+    private String cloudEnv = "prod-3gel427g5936cfa7";
+
+    /**
      * 微信API基础URL
      */
     private String apiBaseUrl = "https://api.weixin.qq.com";

--- a/reminder-backend/reminder-core/src/main/java/com/core/reminder/controller/FileUploadController.java
+++ b/reminder-backend/reminder-core/src/main/java/com/core/reminder/controller/FileUploadController.java
@@ -1,0 +1,36 @@
+package com.core.reminder.controller;
+
+import com.core.reminder.service.StorageService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/files")
+public class FileUploadController {
+
+    private final StorageService storageService;
+
+    @Autowired
+    public FileUploadController(StorageService storageService) {
+        this.storageService = storageService;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<Map<String, String>> handleFileUpload(@RequestParam("file") MultipartFile file) {
+        try {
+            String fileId = storageService.store(file);
+            // 注意：我们现在返回的是fileID，前端的逻辑需要能够处理它
+            // 前端已经有处理 cloud:// 链接的逻辑，所以这里直接返回fileID是可行的
+            return ResponseEntity.ok(Collections.singletonMap("url", fileId));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseEntity.status(500).body(Collections.singletonMap("error", "File upload failed: " + e.getMessage()));
+        }
+    }
+} 

--- a/reminder-backend/reminder-core/src/main/java/com/core/reminder/security/WebSecurityConfig.java
+++ b/reminder-backend/reminder-core/src/main/java/com/core/reminder/security/WebSecurityConfig.java
@@ -1,0 +1,85 @@
+package com.core.reminder.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private JwtAuthenticationEntryPoint unauthorizedHandler;
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter();
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
+        authenticationManagerBuilder
+                .userDetailsService(customUserDetailsService)
+                .passwordEncoder(passwordEncoder());
+    }
+
+    @Bean(BeanIds.AUTHENTICATION_MANAGER)
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .cors()
+                .and()
+            .csrf()
+                .disable()
+            .exceptionHandling()
+                .authenticationEntryPoint(unauthorizedHandler)
+                .and()
+            .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+            .authorizeRequests()
+                .antMatchers("/",
+                    "/favicon.ico",
+                    "/**/*.png",
+                    "/**/*.gif",
+                    "/**/*.svg",
+                    "/**/*.jpg",
+                    "/**/*.html",
+                    "/**/*.css",
+                    "/**/*.js",
+                    "/api/files/**") // 允许文件上传接口
+                    .permitAll()
+                .antMatchers("/api/auth/**", "/oauth2/**")
+                    .permitAll()
+                .antMatchers("/api/holidays/**")
+                    .permitAll()
+                .anyRequest()
+                    .authenticated();
+
+        // Add our custom JWT security filter
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+} 

--- a/reminder-backend/reminder-core/src/main/java/com/core/reminder/service/StorageService.java
+++ b/reminder-backend/reminder-core/src/main/java/com/core/reminder/service/StorageService.java
@@ -1,0 +1,98 @@
+package com.core.reminder.service;
+
+import com.core.reminder.config.WechatConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+@Service
+@Slf4j
+public class StorageService {
+
+    @Autowired
+    private WechatAccessTokenService wechatAccessTokenService;
+
+    @Autowired
+    private WechatConfig wechatConfig;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String UPLOAD_FILE_META_URL = "https://api.weixin.qq.com/tcb/uploadfile?access_token=%s";
+
+    public String store(MultipartFile file) throws IOException {
+        String accessToken = wechatAccessTokenService.getAccessToken();
+        
+        // 1. 获取上传元数据
+        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+        String extension = StringUtils.getFilenameExtension(originalFilename);
+        String cloudPath = "mp_avatar/" + UUID.randomUUID().toString() + "." + extension;
+
+        RestTemplate restTemplate = new RestTemplate();
+        String getMetaUrl = String.format(UPLOAD_FILE_META_URL, accessToken);
+        
+        HttpHeaders metaHeaders = new HttpHeaders();
+        metaHeaders.setContentType(MediaType.APPLICATION_JSON);
+        
+        String requestBody = String.format("{\"env\": \"%s\", \"path\": \"%s\"}", wechatConfig.getCloudEnv(), cloudPath);
+        HttpEntity<String> metaEntity = new HttpEntity<>(requestBody, metaHeaders);
+        
+        ResponseEntity<String> metaResponse = restTemplate.postForEntity(getMetaUrl, metaEntity, String.class);
+        JsonNode metaRoot = objectMapper.readTree(metaResponse.getBody());
+
+        if (metaRoot.has("errcode") && metaRoot.get("errcode").asInt() != 0) {
+            throw new RuntimeException("Failed to get upload metadata: " + metaRoot.get("errmsg").asText());
+        }
+
+        String uploadUrl = metaRoot.get("url").asText();
+        String token = metaRoot.get("token").asText();
+        String authorization = metaRoot.get("authorization").asText();
+        String fileId = metaRoot.get("file_id").asText();
+        String cosFileId = metaRoot.get("cos_file_id").asText();
+
+        // 2. 上传文件
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("key", cloudPath);
+        body.add("Signature", authorization);
+        body.add("x-cos-security-token", token);
+        body.add("x-cos-meta-fileid", cosFileId);
+        
+        ByteArrayResource fileAsResource = new ByteArrayResource(file.getBytes()){
+            @Override
+            public String getFilename(){
+                return originalFilename;
+            }
+        };
+        body.add("file", fileAsResource);
+
+        HttpHeaders uploadHeaders = new HttpHeaders();
+        uploadHeaders.setContentType(MediaType.MULTIPART_FORM_DATA);
+        
+        HttpEntity<MultiValueMap<String, Object>> uploadEntity = new HttpEntity<>(body, uploadHeaders);
+        
+        ResponseEntity<String> uploadResponse = restTemplate.postForEntity(uploadUrl, uploadEntity, String.class);
+
+        if (uploadResponse.getStatusCode().is2xxSuccessful()) {
+            log.info("File uploaded successfully to WeChat Cloud Storage. FileID: {}", fileId);
+            return fileId;
+        } else {
+            throw new RuntimeException("Failed to upload file to WeChat Cloud Storage. Status: " + uploadResponse.getStatusCode());
+        }
+    }
+} 

--- a/reminder-backend/reminder-core/src/main/java/com/core/reminder/service/WechatAccessTokenService.java
+++ b/reminder-backend/reminder-core/src/main/java/com/core/reminder/service/WechatAccessTokenService.java
@@ -1,0 +1,66 @@
+package com.core.reminder.service;
+
+import com.core.reminder.config.WechatConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+public class WechatAccessTokenService {
+
+    @Autowired
+    private WechatConfig wechatConfig;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String accessToken;
+    private LocalDateTime tokenExpiryTime;
+
+    private static final String TOKEN_URL = "https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=%s&secret=%s";
+
+    public String getAccessToken() {
+        if (accessToken == null || LocalDateTime.now().isAfter(tokenExpiryTime)) {
+            fetchNewAccessToken();
+        }
+        return accessToken;
+    }
+
+    private synchronized void fetchNewAccessToken() {
+        // Double-check locking to prevent multiple threads from fetching at the same time
+        if (accessToken != null && !LocalDateTime.now().isAfter(tokenExpiryTime)) {
+            return;
+        }
+
+        log.info("Fetching new WeChat access token...");
+        RestTemplate restTemplate = new RestTemplate();
+        String url = String.format(TOKEN_URL, wechatConfig.getAppid(), wechatConfig.getSecret());
+
+        try {
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+            JsonNode root = objectMapper.readTree(response.getBody());
+
+            if (root.has("access_token")) {
+                this.accessToken = root.get("access_token").asText();
+                long expiresIn = root.get("expires_in").asLong();
+                // Expire 5 minutes early to be safe
+                this.tokenExpiryTime = LocalDateTime.now().plusSeconds(expiresIn - 300);
+                log.info("Successfully fetched new WeChat access token.");
+            } else {
+                String errMsg = root.has("errmsg") ? root.get("errmsg").asText() : "Unknown error";
+                log.error("Failed to fetch WeChat access token: {}", errMsg);
+                throw new RuntimeException("Failed to fetch WeChat access token: " + errMsg);
+            }
+        } catch (Exception e) {
+            log.error("Error fetching WeChat access token", e);
+            throw new RuntimeException("Error fetching WeChat access token", e);
+        }
+    }
+} 

--- a/reminder-backend/reminder-core/src/main/resources/application.yaml
+++ b/reminder-backend/reminder-core/src/main/resources/application.yaml
@@ -119,6 +119,8 @@ wechat:
     appid: wx597f8aaca581205f
     # 小程序AppSecret
     secret: b70c1fd582a6f6d66e8dc1e2e436d023
+    # 微信云开发环境ID
+    cloud-env: prod-3gel427g5936cfa7
     # 微信API基础URL
     api-base-url: https://api.weixin.qq.com
     # 获取session_key的URL路径
@@ -133,3 +135,10 @@ wechat:
     template-id: VXTd9P8DUPpM0aM-nLSHSkDC9KTUolBNhkAHV7UkqxQ
     # 默认跳转页面
     page: index
+
+# 文件存储配置
+storage:
+  # 上传文件存储的根目录（可以是绝对路径，如 /var/uploads/reminder）
+  location: "uploads"
+  # 公共访问URL路径
+  public-path: "/files"

--- a/reminder-uni-app/src/pages/profile/edit.vue
+++ b/reminder-uni-app/src/pages/profile/edit.vue
@@ -144,19 +144,20 @@ export default {
       }
     };
 
-    // 更新成功处理 (此部分无变化)
+    // 更新成功处理
     const onUpdateSuccess = (data) => {
       console.log('编辑资料页面: 用户信息更新成功:', data);
       if (data.userInfo) {
-        const userToSave = { ...userState.user, ...data.userInfo };
-        saveUserInfo(userToSave);
+        // 直接更新共享的用户状态
+        Object.assign(userState.user, data.userInfo);
+        console.log('本地用户状态已更新');
       }
       setTimeout(() => {
         goBack();
       }, 1000);
     };
 
-    // 取消处理 (此部分无变化)
+    // 取消处理
     const onUpdateCancel = () => {
       console.log('编辑资料页面: 用户取消编辑资料');
       goBack();


### PR DESCRIPTION
…用户资料 - 传统登录：新增updateWechatUserLoginInfo方法，只更新登录相关信息 - 新用户注册时仍使用微信信息初始化用户资料 - 解决用户修改头像后重新登录被微信头像覆盖的问题